### PR TITLE
Add gain control to GUI

### DIFF
--- a/StarCameraGUI_v3.py
+++ b/StarCameraGUI_v3.py
@@ -1409,7 +1409,7 @@ class GUI(QDialog):
         # get blob parameters from GUI
         if self.make_staticHP.isChecked():
             # threshold for pixel value to be a static hot pixel
-            make_HP_bool = 20           
+            make_HP_bool = 150 # yields similar # of hot pixels to iDS' own hot pixel finder
         else:
             make_HP_bool = 0
         

--- a/StarCameraGUI_v3.py
+++ b/StarCameraGUI_v3.py
@@ -786,8 +786,8 @@ class GUI(QDialog):
             self.ir_graph_widget.setLabel("left", "IR [deg]", **label_style)
             self.ir_graph_widget.setLabel("right", "IR [deg]", **label_style)
             self.ir_graph_widget.setLabel("bottom", "Raw time [seconds]", **label_style)
-            self.af_graph_widget.setLabel("left", "Flux [raw pixel value]", **label_style)
-            self.af_graph_widget.setLabel("right", "Flux [raw pixel value]", **label_style)
+            self.af_graph_widget.setLabel("left", "Flux [sharpness metric]", **label_style)
+            self.af_graph_widget.setLabel("right", "Flux [sharpness metric]", **label_style)
             self.af_graph_widget.setLabel("bottom", "Focus position [encoder counts]", **label_style)
             # create a reference to the line of each graph for updating telemetry as it arrives
             pen = pg.mkPen(color = "#524f4f", width = 3)
@@ -866,8 +866,8 @@ class GUI(QDialog):
             self.ir_graph_widget.setLabel("left", "IR [deg]", **label_style)
             self.ir_graph_widget.setLabel("right", "IR [deg]", **label_style)
             self.ir_graph_widget.setLabel("bottom", "Raw time [seconds]", **label_style)
-            self.af_graph_widget.setLabel("left", "Flux [raw pixel value]", **label_style)
-            self.af_graph_widget.setLabel("right", "Flux [raw pixel value]", **label_style)
+            self.af_graph_widget.setLabel("left", "Flux [sharpness metric]", **label_style)
+            self.af_graph_widget.setLabel("right", "Flux [sharpness metric]", **label_style)
             self.af_graph_widget.setLabel("bottom", "Focus position [encoder counts]", **label_style)
             # create a reference to the line of each graph for updating telemetry as it arrives
             pen = pg.mkPen(color = "w", width = 3)

--- a/StarCameraGUI_v3.py
+++ b/StarCameraGUI_v3.py
@@ -397,7 +397,7 @@ class GUI(QDialog):
         self.gain_box.setToolTip("Analog CMOS amplifier gain factor (x times base gain ADU/e-)")
         self.gain_box.setMaxLength(9)
         self.gain_box.setText("1.0")
-        self.gain_prev_value = float(self.gain_box.text())
+        self.gain_box_prev_value = float(self.gain_box.text())
         cmd_layout.addRow(QLabel("Sensor Gain (x times base gain):"), self.gain_box)
 
         # timeout for solving Astrometry
@@ -976,7 +976,7 @@ class GUI(QDialog):
         self.ps_box.setText(str(unpacked_data[9]))
         self.auto_focus_state = unpacked_data[26]
         # only add to auto-focusing data if we are in an auto-focusing process
-        if (unpacked_data[24]) and (self.focus_slider.previous_value != unpacked_data[14]):
+        if (unpacked_data[26]) and (self.focus_slider.previous_value != unpacked_data[14]):
             self.auto_focus.append(unpacked_data[14])
             self.flux.append(unpacked_data[31])
         # if every single telemetry data point is 0, esp. pixel scale, that is before first solution of the run
@@ -1355,6 +1355,10 @@ class GUI(QDialog):
             if not still_send:
                 self.exposure_box.setText(str(self.exposure_box_prev_value))
                 return
+            
+        # gain parameter
+        # error checking handled on camera side
+        gain = float(self.gain_box.text())
 
         # Astrometry solving timeout
         timelimit = int(self.timelimit.value())

--- a/listening_final.py
+++ b/listening_final.py
@@ -12,7 +12,7 @@ BYTES_PER_PX = 2 # 12-bit capture mode requires 16-bit image transfers
 
 # 8 x used to skip the pointing uncertainty bytes as the GUI is not designed to handle this
 ASTROMETRY_STRUCT_FMT = "d d d d d d d d d d d d d " + "8x 8x 8x 8x "
-CAMERA_PARAMS_STRUCT_FMT = "i i i i i i i i d d i i i i i i d "
+CAMERA_PARAMS_STRUCT_FMT = "i i i i i i i i d i d i i i i i i i d "
 BLOB_PARAMS_STRUCT_FMT = "i i i i i i i f i i i"
 STARCAM_DATA_SIZE_BYTES = struct.calcsize(ASTROMETRY_STRUCT_FMT + CAMERA_PARAMS_STRUCT_FMT + BLOB_PARAMS_STRUCT_FMT)
 
@@ -46,7 +46,6 @@ def backupStarCamData(StarCam_data):
         CAMERA_PARAMS_STRUCT_FMT +
         BLOB_PARAMS_STRUCT_FMT
     )
-    # unpacked_data = struct.unpack_from("dddddddddddddiiiiiiiiddiiiiiiiiiiiiiifiii", StarCam_data)
     unpacked_data = struct.unpack_from(fmt, StarCam_data)
     text = ["%s," % str(unpacked_data[1]), "%s," % str(time.asctime(time.gmtime(unpacked_data[1]))), 
             "%s," % str(unpacked_data[6]), "%s," % str(unpacked_data[7]), "%s," % str(unpacked_data[8]), 

--- a/listening_final.py
+++ b/listening_final.py
@@ -18,7 +18,6 @@ ASTROMETRY_STRUCT_FMT = "<d d d d d d d d d d d d d 8x 8x 8x 8x"
 CAMERA_PARAMS_STRUCT_FMT = "i i i i i i i i d i d i i i i i i i d"
 BLOB_PARAMS_STRUCT_FMT = "i i i i i i i f i i i"
 STARCAM_DATA_SIZE_BYTES = struct.calcsize(ASTROMETRY_STRUCT_FMT + CAMERA_PARAMS_STRUCT_FMT + BLOB_PARAMS_STRUCT_FMT)
-print(STARCAM_DATA_SIZE_BYTES)
 
 """ 
 Creates and writs information header to the Star Camera data file if it does not already exist. If it does,

--- a/listening_final.py
+++ b/listening_final.py
@@ -12,7 +12,7 @@ BYTES_PER_PX = 2 # 12-bit capture mode requires 16-bit image transfers
 
 # 8 x used to skip the pointing uncertainty bytes as the GUI is not designed to handle this
 ASTROMETRY_STRUCT_FMT = "d d d d d d d d d d d d d " + "8x 8x 8x 8x "
-CAMERA_PARAMS_STRUCT_FMT = "i i i i i i i i d d i i i i i i i "
+CAMERA_PARAMS_STRUCT_FMT = "i i i i i i i i d d i i i i i i d "
 BLOB_PARAMS_STRUCT_FMT = "i i i i i i i f i i i"
 STARCAM_DATA_SIZE_BYTES = struct.calcsize(ASTROMETRY_STRUCT_FMT + CAMERA_PARAMS_STRUCT_FMT + BLOB_PARAMS_STRUCT_FMT)
 

--- a/listening_final.py
+++ b/listening_final.py
@@ -11,10 +11,14 @@ CAMERA_HEIGHT = 3032
 BYTES_PER_PX = 2 # 12-bit capture mode requires 16-bit image transfers
 
 # 8 x used to skip the pointing uncertainty bytes as the GUI is not designed to handle this
-ASTROMETRY_STRUCT_FMT = "d d d d d d d d d d d d d " + "8x 8x 8x 8x "
-CAMERA_PARAMS_STRUCT_FMT = "i i i i i i i i d i d i i i i i i i d "
+# we must use something like =, <, > at the beginning, otherwise the calculated size to
+# unpack will vary according to the number and order of bytes to unpack:
+# https://stackoverflow.com/a/12134822
+ASTROMETRY_STRUCT_FMT = "<d d d d d d d d d d d d d 8x 8x 8x 8x"
+CAMERA_PARAMS_STRUCT_FMT = "i i i i i i i i d i d i i i i i i i d"
 BLOB_PARAMS_STRUCT_FMT = "i i i i i i i f i i i"
 STARCAM_DATA_SIZE_BYTES = struct.calcsize(ASTROMETRY_STRUCT_FMT + CAMERA_PARAMS_STRUCT_FMT + BLOB_PARAMS_STRUCT_FMT)
+print(STARCAM_DATA_SIZE_BYTES)
 
 """ 
 Creates and writs information header to the Star Camera data file if it does not already exist. If it does,


### PR DESCRIPTION
Also:
* Make sharpness a float (really, double) - contrast-based AF involves non-int numbers being sent back
* Fix hot pixel mask making threshold value to be sane for 12bit

GUI has input box for gain, and other fields are not scrambled:
![image](https://github.com/user-attachments/assets/92f0db66-ecbf-4729-b1b5-46a3feaa8a26)


Sets gain on command, and camera software limits setting according to self-reported limits:
```
+---------------------------------------------------------+
| 		User Commands 				  |
|---------------------------------------------------------|
|	Logodds command: 100000000.000000			  |
|	Latitude | longitude: 32.233315 | -110.948556	  |
|	Exposure command in commands.c: 100.000000	  |
|	Gain command in commands.c: 16.000000			  |
|	Astrometry timeout: 1.000000			  |
|	Focus mode: Normal focus			  |
|	Start focus: 25, end focus: 25, focus step: 5	  |
|	Photos per focus: 3				  |
|	Focus position command: 0.000000		  |
|	Set focus to infinity bool command: 0		  |
|	Aperture steps command: 0			  |
|	Set aperture max bool: 0			  |
|	Make static hp mask: 0, use static hp mask: 1	  |
|	Blob parameters: 3.000000, 0.000000, 1.000000	  |
|			 1.000000, 10.000000, 1.000000	  |
|			 0.000000, 10.000000, 15.000000	  |
+---------------------------------------------------------+

Focus change to fulfill user cmd: 0
setMonoAnalogGain: Available gain range is 1.000000 - 15.848932, step 0.010000.
getMonoAnalogGain: actual gain is 15.848932x
```